### PR TITLE
Updates implementation to use informers, rather than pure watches

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,12 +28,13 @@ docker-compose.yaml
 **/.vscode
 
 # CI-runner files
+.drone.yml
+.drone.yaml
+.github
 .gitlab-ci.yml
 .gitlab-ci.yaml
 .travis.yml
 .travis.yaml
-.drone.yml
-.drone.yaml
 
 # General project files
 README.md

--- a/cmd/hosts-file-daemon/daemon.go
+++ b/cmd/hosts-file-daemon/daemon.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	// "context"
 	"errors"
 	"fmt"
 	"log"

--- a/cmd/hosts-file-daemon/daemon.go
+++ b/cmd/hosts-file-daemon/daemon.go
@@ -70,11 +70,8 @@ func Run(daemonConfig *DaemonConfig) {
 	go func() {
 		time.Sleep(time.Second * 60)
 		log.Println("Forcing update of hostsfile to ensure initial launch configurations persist")
-		hostfileContents := hostsFile.String()
-		err := WriteHostsFileAndRestartPihole(daemonConfig, hostfileContents)
-		if err != nil {
-			log.Fatal(err)
-		}
+		hostsfile := hostsFile.String()
+		updatesChannel <- &hostsfile
 	}()
 
 	interrupt.WaitForAnySignal(syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/hosts-file-daemon/daemon.go
+++ b/cmd/hosts-file-daemon/daemon.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"context"
+	// "context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -10,10 +11,15 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
+	// extensionsv1beta1 "k8s.io/client-go/kubernetes/typed/networking/v1beta1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	// "k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/Eagerod/hosts-file-daemon/pkg/hostsfile"
 	"github.com/Eagerod/hosts-file-daemon/pkg/interrupt"
@@ -69,97 +75,165 @@ func Run(daemonConfig *DaemonConfig) {
 	interrupt.WaitForAnySignal(syscall.SIGINT, syscall.SIGTERM)
 }
 
+func GetNginxIngress(obj interface{}) (*extensionsv1beta1.Ingress, *string, error) {
+	ingress, ok := obj.(*extensionsv1beta1.Ingress)
+	if !ok {
+		return nil, nil, errors.New(fmt.Sprintf("Failed to get ingress from provided object."))
+	}
+
+	objectId := ingress.ObjectMeta.Namespace + "/" + ingress.ObjectMeta.Name
+
+	ingressClass, ok := ingress.Annotations["kubernetes.io/ingress.class"]
+	if !ok {
+		return nil, &objectId, errors.New(fmt.Sprintf("Skipping ingress (%s) because it doesn't have an ingress class\n", objectId))
+	}
+
+	if ingressClass != "nginx" {
+		return nil, &objectId, errors.New(fmt.Sprintf("Skipping ingress (%s) because it doesn't belong to NGINX Ingress Controller\n", objectId))
+	}
+
+	return ingress, &objectId, nil
+}
+
+func UpdateHostsFromIngress(hosts *hostsfile.ConcurrentHostsFile, ingress *extensionsv1beta1.Ingress, objectId string, ingressIp string) {
+	hostnames := []string{}
+	for _, rule := range ingress.Spec.Rules {
+		if strings.HasSuffix(rule.Host, ingressIp) {
+			hostnames = append(hostnames, rule.Host+".")
+		} else {
+			hostnames = append(hostnames, rule.Host)
+		}
+	}
+	hosts.SetHostnames(objectId, ingressIp, hostnames)
+}
+
 func ManageIngressChanges(daemonConfig *DaemonConfig, updatesChannel chan *string, hosts *hostsfile.ConcurrentHostsFile) {
-	api := daemonConfig.KubernetesClientSet.ExtensionsV1beta1()
-	listOptions := metav1.ListOptions{}
-	watcher, err := api.Ingresses("").Watch(context.Background(), listOptions)
+	// Resync every minute, just in case something somehow gets missed.
+	informerFactory := informers.NewSharedInformerFactory(daemonConfig.KubernetesClientSet, time.Minute)
 
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	ch := watcher.ResultChan()
-	log.Println("Starting to monitor ingresses in all namespaces.")
-
-	for event := range ch {
-		ingress, ok := event.Object.(*extensionsv1beta1.Ingress)
-		if !ok {
-			log.Fatal("unexpected type")
-		}
-
-		objectId := ingress.ObjectMeta.Namespace + "/" + ingress.ObjectMeta.Name
-
-		ingressClass, ok := ingress.Annotations["kubernetes.io/ingress.class"]
-		if !ok {
-			log.Printf("Skipping ingress (%s) because it doesn't have an ingress class\n", objectId)
-			continue
-		}
-
-		if ingressClass != "nginx" {
-			log.Printf("Skipping ingress (%s) because it doesn't belong to NGINX Ingress Controller\n", objectId)
-			continue
-		}
-
-		// For each host found, add a record to the hosts file.
-		// If this is an fqdn already, add it with a ., else add it as-is
-		if event.Type == "ADDED" || event.Type == "MODIFIED" {
-			hostnames := []string{}
-			for _, rule := range ingress.Spec.Rules {
-				if strings.HasSuffix(rule.Host, daemonConfig.IngressIp) {
-					hostnames = append(hostnames, rule.Host+".")
-				} else {
-					hostnames = append(hostnames, rule.Host)
+	ingressInformer := informerFactory.Extensions().V1beta1().Ingresses()
+	
+	ingressInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+            AddFunc: func(obj interface{}) {
+				ingress, objectId, err := GetNginxIngress(obj)
+				if err != nil {
+					log.Println(err.Error())
+					return
 				}
-			}
-			hosts.SetHostnames(objectId, daemonConfig.IngressIp, hostnames)
-		} else if event.Type == "DELETED" {
-			hosts.RemoveHostnames(objectId)
-		}
 
-		hostsFile := hosts.String()
-		updatesChannel <- &hostsFile
+				UpdateHostsFromIngress(hosts, ingress, *objectId, daemonConfig.IngressIp)
+				
+				hostsFile := hosts.String()
+				updatesChannel <- &hostsFile
+            },
+            DeleteFunc: func(obj interface{}) {
+				_, objectId, err := GetNginxIngress(obj)
+				if err != nil {
+					log.Println(err.Error())
+					return
+				}
+
+				hosts.RemoveHostnames(*objectId)
+				
+				hostsFile := hosts.String()
+				updatesChannel <- &hostsFile
+            },
+            UpdateFunc:func(oldObj, newObj interface{}) {
+				ingress, objectId, err := GetNginxIngress(newObj)
+				if err != nil {
+					log.Println(err.Error())
+					return
+				}
+
+				UpdateHostsFromIngress(hosts, ingress, *objectId, daemonConfig.IngressIp)
+
+				hostsFile := hosts.String()
+				updatesChannel <- &hostsFile
+            },
+        },
+	)
+		
+    stop := make(chan struct{})
+	informerFactory.Start(stop)
+	informerFactory.WaitForCacheSync(stop)
+}
+
+func GetLoadBalancerService(obj interface{}) (*v1.Service, *string, error) {
+	service, ok := obj.(*v1.Service)
+	if !ok {
+		return nil, nil, errors.New(fmt.Sprintf("Failed to get service from provided object."))
 	}
+
+	objectId := service.ObjectMeta.Namespace + "/" + service.ObjectMeta.Name
+
+	if service.Spec.Type != "LoadBalancer" {
+		return nil, &objectId, errors.New(fmt.Sprintf("Skipping service (%s) because it isn't of type LoadBalancer\n", objectId))
+	}
+
+	return service, &objectId, nil
+}
+
+func UpdateHostsFromService(hosts *hostsfile.ConcurrentHostsFile, service *v1.Service, objectId string, searchDomain string) {
+	// Serivces don't include the full search domain, so append it.
+	serviceName := service.ObjectMeta.Name
+	serviceIp := service.Spec.LoadBalancerIP
+
+	fqdn := serviceName + "." + searchDomain + "."
+	hosts.SetHostnames(objectId, serviceIp, []string{fqdn})
 }
 
 func ManageServiceChanges(daemonConfig *DaemonConfig, updatesChannel chan *string, hosts *hostsfile.ConcurrentHostsFile) {
-	api := daemonConfig.KubernetesClientSet.CoreV1()
-	listOptions := metav1.ListOptions{}
-	watcher, err := api.Services("").Watch(context.Background(), listOptions)
 
-	if err != nil {
-		log.Fatal(err)
-	}
+	// Resync every minute, just in case something somehow gets missed.
+	informerFactory := informers.NewSharedInformerFactory(daemonConfig.KubernetesClientSet, time.Minute)
 
-	ch := watcher.ResultChan()
-	log.Printf("Starting to monitor services in all namespaces.")
+	serviceInformer := informerFactory.Core().V1().Services()
+	
+	serviceInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				service, objectId, err := GetLoadBalancerService(obj)
+				if err != nil {
+					log.Println(err.Error())
+					return
+				}
 
-	for event := range ch {
-		service, ok := event.Object.(*v1.Service)
-		if !ok {
-			log.Fatal("unexpected type")
-		}
+				UpdateHostsFromService(hosts, service, *objectId, daemonConfig.SearchDomain)
+				
+				hostsFile := hosts.String()
+				updatesChannel <- &hostsFile
+			},
+			DeleteFunc: func(obj interface{}) {
+				_, objectId, err := GetLoadBalancerService(obj)
+				if err != nil {
+					log.Println(err.Error())
+					return
+				}
 
-		objectId := service.ObjectMeta.Namespace + "/" + service.ObjectMeta.Name
+				hosts.RemoveHostnames(*objectId)
+				
+				hostsFile := hosts.String()
+				updatesChannel <- &hostsFile
+			},
+			UpdateFunc:func(oldObj, newObj interface{}) {
+				service, objectId, err := GetLoadBalancerService(newObj)
+				if err != nil {
+					log.Println(err.Error())
+					return
+				}
 
-		if service.Spec.Type != "LoadBalancer" {
-			log.Printf("Skipping service (%s) because it isn't of type LoadBalancer\n", objectId)
-			continue
-		}
+				UpdateHostsFromService(hosts, service, *objectId, daemonConfig.SearchDomain)
 
-		// Serivces don't include the full search domain, so append it.
-		serviceName := service.ObjectMeta.Name
-		serviceIp := service.Spec.LoadBalancerIP
-
-		fqdn := serviceName + "." + daemonConfig.SearchDomain + "."
-		if event.Type == "ADDED" || event.Type == "MODIFIED" {
-			hosts.SetHostnames(objectId, serviceIp, []string{fqdn})
-		} else if event.Type == "DELETED" {
-			hosts.RemoveHostnames(objectId)
-		}
-
-		hostsFile := hosts.String()
-		updatesChannel <- &hostsFile
-	}
+				hostsFile := hosts.String()
+				updatesChannel <- &hostsFile
+			},
+		},
+	)
+		
+	stop := make(chan struct{})
+	informerFactory.Start(stop)
+	informerFactory.WaitForCacheSync(stop)
 }
 
 func WriteHostsFileAndRestartPihole(daemonConfig *DaemonConfig, hostsfile string) error {

--- a/cmd/hosts-file-daemon/daemon.go
+++ b/cmd/hosts-file-daemon/daemon.go
@@ -68,6 +68,16 @@ func Run(daemonConfig *DaemonConfig) {
 	go ManageIngressChanges(daemonConfig, updatesChannel, hostsFile)
 	go ManageServiceChanges(daemonConfig, updatesChannel, hostsFile)
 
+	go func() {
+		time.Sleep(time.Second * 60)
+		log.Println("Forcing update of hostsfile to ensure initial launch configurations persist")
+		hostfileContents := hostsFile.String()
+		err := WriteHostsFileAndRestartPihole(daemonConfig, hostfileContents)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
 	interrupt.WaitForAnySignal(syscall.SIGINT, syscall.SIGTERM)
 }
 

--- a/cmd/hosts-file-daemon/daemon.go
+++ b/cmd/hosts-file-daemon/daemon.go
@@ -13,8 +13,8 @@ import (
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/Eagerod/hosts-file-daemon/pkg/hostsfile"
 	"github.com/Eagerod/hosts-file-daemon/pkg/interrupt"
@@ -117,10 +117,10 @@ func ManageIngressChanges(daemonConfig *DaemonConfig, updatesChannel chan *strin
 	informerFactory := informers.NewSharedInformerFactory(daemonConfig.KubernetesClientSet, time.Minute)
 
 	ingressInformer := informerFactory.Extensions().V1beta1().Ingresses()
-	
+
 	ingressInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-            AddFunc: func(obj interface{}) {
+			AddFunc: func(obj interface{}) {
 				ingress, objectId, err := GetNginxIngress(obj)
 				if err != nil {
 					return
@@ -131,8 +131,8 @@ func ManageIngressChanges(daemonConfig *DaemonConfig, updatesChannel chan *strin
 					hostsfile := hosts.String()
 					updatesChannel <- &hostsfile
 				}
-            },
-            DeleteFunc: func(obj interface{}) {
+			},
+			DeleteFunc: func(obj interface{}) {
 				_, objectId, err := GetNginxIngress(obj)
 				if err != nil {
 					return
@@ -143,8 +143,8 @@ func ManageIngressChanges(daemonConfig *DaemonConfig, updatesChannel chan *strin
 					hostsFile := hosts.String()
 					updatesChannel <- &hostsFile
 				}
-            },
-            UpdateFunc:func(oldObj, newObj interface{}) {
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
 				ingress, objectId, err := GetNginxIngress(newObj)
 				if err != nil {
 					return
@@ -155,11 +155,11 @@ func ManageIngressChanges(daemonConfig *DaemonConfig, updatesChannel chan *strin
 					hostsFile := hosts.String()
 					updatesChannel <- &hostsFile
 				}
-            },
-        },
+			},
+		},
 	)
-		
-    stop := make(chan struct{})
+
+	stop := make(chan struct{})
 	informerFactory.Start(stop)
 	informerFactory.WaitForCacheSync(stop)
 }
@@ -220,7 +220,7 @@ func ManageServiceChanges(daemonConfig *DaemonConfig, updatesChannel chan *strin
 					updatesChannel <- &hostsfile
 				}
 			},
-			UpdateFunc:func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj interface{}) {
 				service, objectId, err := GetLoadBalancerService(newObj)
 				if err != nil {
 					return
@@ -234,7 +234,7 @@ func ManageServiceChanges(daemonConfig *DaemonConfig, updatesChannel chan *strin
 			},
 		},
 	)
-		
+
 	stop := make(chan struct{})
 	informerFactory.Start(stop)
 	informerFactory.WaitForCacheSync(stop)

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
@@ -133,6 +134,7 @@ github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyyc
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	cmd "github.com/Eagerod/hosts-file-daemon/cmd/hosts-file-daemon"
 )
@@ -40,9 +39,6 @@ func main() {
 			os.Exit(2)
 		}
 	}
-
-	fmt.Fprintf(os.Stderr, "Waiting 60 seconds to allow pihole to start before monitoring resources...\n")
-	time.Sleep(time.Second * 60)
 
 	cmd.Run(daemonConfig)
 }

--- a/pkg/hostsfile/hostsfile.go
+++ b/pkg/hostsfile/hostsfile.go
@@ -39,7 +39,6 @@ func (thisp *HostsEntry) Equals(otherp *HostsEntry) bool {
 type ConcurrentHostsFile struct {
 	lock    *sync.RWMutex
 	entries map[string]*HostsEntry
-	dirty   bool
 }
 
 func NewConcurrentHostsFile() *ConcurrentHostsFile {

--- a/pkg/hostsfile/hostsfile.go
+++ b/pkg/hostsfile/hostsfile.go
@@ -26,7 +26,7 @@ func (thisp *HostsEntry) Equals(otherp *HostsEntry) bool {
 	if len(this.hosts) != len(other.hosts) {
 		return false
 	}
-	
+
 	for i, entry := range this.hosts {
 		if entry != other.hosts[i] {
 			return false

--- a/pkg/hostsfile/hostsfile.go
+++ b/pkg/hostsfile/hostsfile.go
@@ -43,7 +43,7 @@ type ConcurrentHostsFile struct {
 
 func NewConcurrentHostsFile() *ConcurrentHostsFile {
 	mutex := sync.RWMutex{}
-	chf := ConcurrentHostsFile{&mutex, map[string]*HostsEntry{}, false}
+	chf := ConcurrentHostsFile{&mutex, map[string]*HostsEntry{}}
 	return &chf
 }
 


### PR DESCRIPTION
Watches timed out after 20 minutes, and would have to be restarted, figured I'd use the API that resets those connections on its own. 

- Updates so that instead of waiting 60 seconds for the pihole to start, updated immediately, then pushes a manual update after 60 seconds. 
- Outside of that one forced push, only updates on actual changes to the hostsfile, rather than on any incoming event, which could be a no-op.
- Log for successful updates, rather than skips, since there's now a batch of skips every time the informer refreshes.