### PR TITLE
Refactors basically everything; adds tests

### DIFF
--- a/cmd/hostsfile-generator/daemon.go
+++ b/cmd/hostsfile-generator/daemon.go
@@ -2,293 +2,43 @@ package cmd
 
 import (
 	"errors"
+	"flag"
 	"fmt"
-	"log"
 	"os"
-	"strings"
-	"syscall"
-	"time"
 
-	"k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/remotecommand"
-
-	"github.com/Eagerod/hostsfile-generator/pkg/hostsfile"
-	"github.com/Eagerod/hostsfile-generator/pkg/interrupt"
+	"github.com/Eagerod/hostsfile-generator/pkg/daemon"
 )
 
-func Run(daemonConfig *DaemonConfig) {
-	hostsFile := hostsfile.NewConcurrentHostsFile()
+func Run() error {
+	ip := flag.String("ingress-ip", "", "IP address of the NGINX Ingress Controller.")
+	searchDomain := flag.String("search-domain", "", "Search domain to append to bare hostnames.")
+	version := flag.Bool("v", false, "Print the version and exit.")
 
-	updatesChannel := make(chan *string, 100)
-	defer close(updatesChannel)
+	flag.Parse()
 
-	go func() {
-		lastUpdate := time.Now()
-		for hostsfile := range updatesChannel {
-			// Check the length of the channel before doing anything.
-			// If there are more items in it, just let the next iteration
-			//    handle the update.
-			if len(updatesChannel) >= 1 {
-				continue
-			}
-
-			// If the last update was more than 60 seconds ago, write this one
-			//   immediately
-			if time.Now().Sub(lastUpdate).Minutes() >= 1 {
-				log.Println("Last update was more than 1 minute ago. Updating immediately.")
-				err := WriteHostsFileAndRestartPihole(daemonConfig, *hostsfile)
-				if err != nil {
-					log.Fatal(err)
-				}
-				lastUpdate = time.Now()
-				continue
-			}
-
-			// Wait 3 seconds.
-			log.Println("Waiting 1 seconds before attempting hostsfile update.")
-			time.Sleep(time.Second * 1)
-			if len(updatesChannel) >= 1 {
-				log.Println("Aborting hostsfile update. Newer hostsfile is pending.")
-				continue
-			}
-
-			err := WriteHostsFileAndRestartPihole(daemonConfig, *hostsfile)
-			if err != nil {
-				log.Fatal(err)
-			}
-			lastUpdate = time.Now()
-		}
-	}()
-
-	go ManageIngressChanges(daemonConfig, updatesChannel, hostsFile)
-	go ManageServiceChanges(daemonConfig, updatesChannel, hostsFile)
-
-	go func() {
-		time.Sleep(time.Second * 60)
-		log.Println("Forcing update of hostsfile to ensure initial launch configurations persist")
-		hostsfile := hostsFile.String()
-		updatesChannel <- &hostsfile
-	}()
-
-	interrupt.WaitForAnySignal(syscall.SIGINT, syscall.SIGTERM)
-}
-
-func GetNginxIngress(obj interface{}) (*extensionsv1beta1.Ingress, *string, error) {
-	ingress, ok := obj.(*extensionsv1beta1.Ingress)
-	if !ok {
-		return nil, nil, errors.New(fmt.Sprintf("Failed to get ingress from provided object."))
+	if *version == true {
+		fmt.Println(VersionBuild)
+		return nil
 	}
 
-	objectId := ingress.ObjectMeta.Namespace + "/" + ingress.ObjectMeta.Name
-
-	ingressClass, ok := ingress.Annotations["kubernetes.io/ingress.class"]
-	if !ok {
-		return nil, &objectId, errors.New(fmt.Sprintf("Skipping ingress (%s) because it doesn't have an ingress class\n", objectId))
+	if *ip == "" || *searchDomain == "" {
+		flag.Usage()
+		return errors.New("Invalid configuration")
 	}
 
-	if ingressClass != "nginx" {
-		return nil, &objectId, errors.New(fmt.Sprintf("Skipping ingress (%s) because it doesn't belong to NGINX Ingress Controller\n", objectId))
-	}
-
-	return ingress, &objectId, nil
-}
-
-func UpdateHostsFromIngress(hosts hostsfile.IHostsFile, ingress *extensionsv1beta1.Ingress, objectId string, ingressIp string) bool {
-	hostnames := []string{}
-	for _, rule := range ingress.Spec.Rules {
-		if strings.HasSuffix(rule.Host, ingressIp) {
-			hostnames = append(hostnames, rule.Host+".")
-		} else {
-			hostnames = append(hostnames, rule.Host)
-		}
-	}
-
-	he := hostsfile.NewHostsEntry(ingressIp, hostnames)
-	return hosts.SetHostsEntry(objectId, *he)
-}
-
-func ManageIngressChanges(daemonConfig *DaemonConfig, updatesChannel chan *string, hosts hostsfile.IHostsFile) {
-	// Resync every minute, just in case something somehow gets missed.
-	informerFactory := informers.NewSharedInformerFactory(daemonConfig.KubernetesClientSet, time.Minute)
-
-	ingressInformer := informerFactory.Extensions().V1beta1().Ingresses()
-
-	ingressInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				ingress, objectId, err := GetNginxIngress(obj)
-				if err != nil {
-					return
-				}
-
-				if UpdateHostsFromIngress(hosts, ingress, *objectId, daemonConfig.IngressIp) {
-					log.Println("Updating hostsfile from discovered ingress", *objectId)
-					hostsfile := hosts.String()
-					updatesChannel <- &hostsfile
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				_, objectId, err := GetNginxIngress(obj)
-				if err != nil {
-					return
-				}
-
-				if hosts.RemoveHostsEntry(*objectId) {
-					log.Println("Updating hostsfile from removed ingress", *objectId)
-					hostsFile := hosts.String()
-					updatesChannel <- &hostsFile
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				ingress, objectId, err := GetNginxIngress(newObj)
-				if err != nil {
-					return
-				}
-
-				if UpdateHostsFromIngress(hosts, ingress, *objectId, daemonConfig.IngressIp) {
-					log.Println("Updating hostsfile from updated ingress", *objectId)
-					hostsFile := hosts.String()
-					updatesChannel <- &hostsFile
-				}
-			},
-		},
-	)
-
-	stop := make(chan struct{})
-	informerFactory.Start(stop)
-	informerFactory.WaitForCacheSync(stop)
-}
-
-func GetLoadBalancerService(obj interface{}) (*v1.Service, *string, error) {
-	service, ok := obj.(*v1.Service)
-	if !ok {
-		return nil, nil, errors.New(fmt.Sprintf("Failed to get service from provided object."))
-	}
-
-	objectId := service.ObjectMeta.Namespace + "/" + service.ObjectMeta.Name
-
-	if service.Spec.Type != "LoadBalancer" {
-		return nil, &objectId, errors.New(fmt.Sprintf("Skipping service (%s) because it isn't of type LoadBalancer\n", objectId))
-	}
-
-	return service, &objectId, nil
-}
-
-func UpdateHostsFromService(hosts hostsfile.IHostsFile, service *v1.Service, objectId string, searchDomain string) bool {
-	// Serivces don't include the full search domain, so append it.
-	serviceName := service.ObjectMeta.Name
-	serviceIp := service.Spec.LoadBalancerIP
-
-	fqdn := serviceName + "." + searchDomain + "."
-	he := hostsfile.NewHostsEntry(serviceIp, []string{fqdn})
-	return hosts.SetHostsEntry(objectId, *he)
-}
-
-func ManageServiceChanges(daemonConfig *DaemonConfig, updatesChannel chan *string, hosts hostsfile.IHostsFile) {
-	// Resync every minute, just in case something somehow gets missed.
-	informerFactory := informers.NewSharedInformerFactory(daemonConfig.KubernetesClientSet, time.Minute)
-
-	serviceInformer := informerFactory.Core().V1().Services()
-
-	serviceInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				service, objectId, err := GetLoadBalancerService(obj)
-				if err != nil {
-					return
-				}
-
-				if UpdateHostsFromService(hosts, service, *objectId, daemonConfig.SearchDomain) {
-					log.Println("Updating hostsfile from discovered service", *objectId)
-					hostsfile := hosts.String()
-					updatesChannel <- &hostsfile
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				_, objectId, err := GetLoadBalancerService(obj)
-				if err != nil {
-					return
-				}
-
-				if hosts.RemoveHostsEntry(*objectId) {
-					log.Println("Updating hostsfile from removed service", *objectId)
-					hostsfile := hosts.String()
-					updatesChannel <- &hostsfile
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				service, objectId, err := GetLoadBalancerService(newObj)
-				if err != nil {
-					return
-				}
-
-				if UpdateHostsFromService(hosts, service, *objectId, daemonConfig.SearchDomain) {
-					log.Println("Updating hostsfile from updated service", *objectId)
-					hostsfile := hosts.String()
-					updatesChannel <- &hostsfile
-				}
-			},
-		},
-	)
-
-	stop := make(chan struct{})
-	informerFactory.Start(stop)
-	informerFactory.WaitForCacheSync(stop)
-}
-
-func WriteHostsFileAndRestartPihole(daemonConfig *DaemonConfig, hostsfile string) error {
-	log.Println("Updating kube.list in pod:", daemonConfig.PiholePodName)
-	if err := CopyFileToPod(daemonConfig, "/etc/pihole/kube.list", hostsfile); err != nil {
-		return err
-	}
-
-	log.Println("Restarting DNS service in pod:", daemonConfig.PiholePodName)
-	if err := ExecInPod(daemonConfig, []string{"pihole", "restartdns"}); err != nil {
-		return err
-	}
-
-	log.Println("Successfully restarted DNS service in pod:", daemonConfig.PiholePodName)
-	return nil
-}
-
-func CopyFileToPod(daemonConfig *DaemonConfig, filepath string, contents string) error {
-	// There's certainly a more correct way of doing this, but that's a lot of
-	//   extra code.
-	script := fmt.Sprintf("cat <<EOF > %s\n%s\nEOF", filepath, contents)
-	return ExecInPod(daemonConfig, []string{"sh", "-c", script})
-}
-
-func ExecInPod(daemonConfig *DaemonConfig, command []string) error {
-	api := daemonConfig.KubernetesClientSet.CoreV1()
-
-	execResource := api.RESTClient().Post().Resource("pods").Name(daemonConfig.PiholePodName).
-		Namespace("default").SubResource("exec").Param("container", "pihole")
-
-	podExecOptions := &v1.PodExecOptions{
-		Command: command,
-		Stdin:   true,
-		Stdout:  true,
-		Stderr:  true,
-		TTY:     true,
-	}
-
-	execResource.VersionedParams(
-		podExecOptions,
-		scheme.ParameterCodec,
-	)
-
-	exec, err := remotecommand.NewSPDYExecutor(daemonConfig.RestConfig, "POST", execResource.URL())
+	daemonConfig, err := daemon.NewDaemonConfigInCluster(*ip, *searchDomain)
 	if err != nil {
-		return err
+		serverIp := os.Getenv("SERVER_IP")
+		sat := os.Getenv("SERVICE_ACCOUNT_TOKEN")
+		piholePodName := os.Getenv("PIHOLE_POD_NAME")
+
+		daemonConfig, err = daemon.NewDaemonConfig(*ip, *searchDomain, serverIp, sat, piholePodName)
+		if err != nil {
+			return err
+		}
 	}
 
-	return exec.Stream(remotecommand.StreamOptions{
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	})
+	d := daemon.NewHostsFileDaemon(*daemonConfig)
+	d.Run()
+	return nil
 }

--- a/cmd/hostsfile-generator/daemon.go
+++ b/cmd/hostsfile-generator/daemon.go
@@ -26,6 +26,8 @@ func Run() error {
 		return errors.New("Invalid configuration")
 	}
 
+	// If running in the cluster, pull the service account token, else, pull
+	//   the values from an environment variable.
 	daemonConfig, err := daemon.NewDaemonConfigInCluster(*ip, *searchDomain)
 	if err != nil {
 		serverIp := os.Getenv("SERVER_IP")

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -11,34 +10,8 @@ import (
 )
 
 func main() {
-	ip := flag.String("ingress-ip", "", "IP address of the NGINX Ingress Controller.")
-	searchDomain := flag.String("search-domain", "", "Search domain to append to bare hostnames.")
-	version := flag.Bool("v", false, "Print the version and exit.")
-
-	flag.Parse()
-
-	if *version == true {
-		fmt.Println(cmd.VersionBuild)
-		return
-	}
-
-	if *ip == "" || *searchDomain == "" {
-		flag.Usage()
-		os.Exit(1)
-	}
-
-	daemonConfig, err := cmd.NewDaemonConfigInCluster(*ip, *searchDomain)
+	err := cmd.Run()
 	if err != nil {
-		serverIp := os.Getenv("SERVER_IP")
-		sat := os.Getenv("SERVICE_ACCOUNT_TOKEN")
-		piholePodName := os.Getenv("PIHOLE_POD_NAME")
-
-		daemonConfig, err = cmd.NewDaemonConfig(*ip, *searchDomain, serverIp, sat, piholePodName)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, err.Error())
-			os.Exit(2)
-		}
+		fmt.Fprintf(os.Stderr, err.Error())
 	}
-
-	cmd.Run(daemonConfig)
 }

--- a/pkg/daemon/daemon_config.go
+++ b/pkg/daemon/daemon_config.go
@@ -45,7 +45,7 @@ func NewDaemonConfigInCluster(ingressIp string, searchDomain string) (*DaemonCon
 	return &daemonConfig, nil
 }
 
-func NewDaemonConfig(ingressIp string, searchDomain string, clusterIp string, bearerToken string, piholePodName string) (*DaemonConfig, error) {
+func NewDaemonConfig(ingressIp, searchDomain, clusterIp, bearerToken, piholePodName string) (*DaemonConfig, error) {
 	config := &rest.Config{}
 	err := rest.SetKubernetesDefaults(config)
 	if err != nil {

--- a/pkg/daemon/daemon_config.go
+++ b/pkg/daemon/daemon_config.go
@@ -1,4 +1,4 @@
-package cmd
+package daemon
 
 import (
 	"errors"

--- a/pkg/daemon/daemon_config.go
+++ b/pkg/daemon/daemon_config.go
@@ -20,13 +20,12 @@ type DaemonConfig struct {
 }
 
 // Assumes that this is running in the same pod as the pihole.
-// Uses the pod's own hostname to
+// Uses the pod's own hostname to find the pod's name.
 func NewDaemonConfigInCluster(ingressIp string, searchDomain string) (*DaemonConfig, error) {
 	if _, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token"); os.IsNotExist(err) {
 		return nil, errors.New("Cannot find service account token. Maybe it hasn't been attached?")
 	}
 
-	// path/to/whatever does not exist
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -47,8 +46,6 @@ func NewDaemonConfigInCluster(ingressIp string, searchDomain string) (*DaemonCon
 }
 
 func NewDaemonConfig(ingressIp string, searchDomain string, clusterIp string, bearerToken string, piholePodName string) (*DaemonConfig, error) {
-	// If running in the cluster, pull the service account token, else, pull
-	//   the token from an environment variable.
 	config := &rest.Config{}
 	err := rest.SetKubernetesDefaults(config)
 	if err != nil {

--- a/pkg/daemon/daemon_ingress_monitor.go
+++ b/pkg/daemon/daemon_ingress_monitor.go
@@ -13,7 +13,6 @@ import (
 )
 
 type DaemonIngressMonitor struct {
-	hostsfile hostsfile.IHostsFile
 	ingressIp string
 }
 

--- a/pkg/daemon/daemon_ingress_monitor.go
+++ b/pkg/daemon/daemon_ingress_monitor.go
@@ -13,7 +13,8 @@ import (
 )
 
 type DaemonIngressMonitor struct {
-	ingressIp string
+	ingressIp    string
+	searchDomain string
 }
 
 func (d *DaemonIngressMonitor) Name() string {
@@ -53,7 +54,7 @@ func (d *DaemonIngressMonitor) GetResourceHostsEntry(obj interface{}) hostsfile.
 	hostnames := []string{}
 
 	for _, rule := range ingress.Spec.Rules {
-		if strings.HasSuffix(rule.Host, d.ingressIp) {
+		if strings.HasSuffix(rule.Host, d.searchDomain) {
 			hostnames = append(hostnames, rule.Host+".")
 		} else {
 			hostnames = append(hostnames, rule.Host)

--- a/pkg/daemon/daemon_ingress_monitor.go
+++ b/pkg/daemon/daemon_ingress_monitor.go
@@ -17,6 +17,10 @@ type DaemonIngressMonitor struct {
 	ingressIp string
 }
 
+func (d *DaemonIngressMonitor) Name() string {
+	return "ingress"
+}
+
 func (d *DaemonIngressMonitor) Informer(sif informers.SharedInformerFactory) cache.SharedInformer {
 	return sif.Extensions().V1beta1().Ingresses().Informer()
 }

--- a/pkg/daemon/daemon_ingress_monitor.go
+++ b/pkg/daemon/daemon_ingress_monitor.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/Eagerod/hostsfile-generator/pkg/hostsfile"
+)
+
+type DaemonIngressMonitor struct {
+	hfd *HostsFileDaemon
+}
+
+func (d *DaemonIngressMonitor) Informer(sif informers.SharedInformerFactory) cache.SharedInformer {
+	return sif.Extensions().V1beta1().Ingresses().Informer()
+}
+
+func (d *DaemonIngressMonitor) ValidateResource(obj interface{}) (string, error) {
+	ingress, ok := obj.(*extensionsv1beta1.Ingress)
+	if !ok {
+		return "", errors.New("Failed to get ingress from provided object.")
+	}
+
+	objectId := fmt.Sprintf("%s/%s", ingress.ObjectMeta.Namespace, ingress.ObjectMeta.Name)
+
+	ingressClass, ok := ingress.Annotations["kubernetes.io/ingress.class"]
+	if !ok {
+		return objectId, fmt.Errorf("Skipping ingress (%s) because it doesn't have an ingress class.", objectId)
+	}
+
+	if ingressClass != "nginx" {
+		return objectId, fmt.Errorf("Skipping ingress (%s) because it doesn't belong to NGINX Ingress Controller.", objectId)
+	}
+
+	return objectId, nil
+}
+
+func (d *DaemonIngressMonitor) HandleNewResource(objectId string, obj interface{}) bool {
+	ingress, ok := obj.(*extensionsv1beta1.Ingress)
+	if !ok {
+		return false
+	}
+
+	if d.setHostsEntry(objectId, ingress) {
+		log.Println("Updating hostsfile from discovered ingress", objectId)
+		return true
+	}
+
+	return false
+}
+
+func (d *DaemonIngressMonitor) HandleDeletedResource(objectId string, obj interface{}) bool {
+	_, ok := obj.(*extensionsv1beta1.Ingress)
+	if !ok {
+		return false
+	}
+
+	if d.hfd.hostsfile.RemoveHostsEntry(objectId) {
+		log.Println("Updating hostsfile from removed ingress", objectId)
+		return true
+	}
+
+	return false
+}
+
+func (d *DaemonIngressMonitor) HandleUpdatedResource(objectId string, obj interface{}) bool {
+	ingress, ok := obj.(*extensionsv1beta1.Ingress)
+	if !ok {
+		return false
+	}
+
+	if d.setHostsEntry(objectId, ingress) {
+		log.Println("Updating hostsfile from updated ingress", objectId)
+		return true
+	}
+
+	return false
+}
+
+func (d *DaemonIngressMonitor) setHostsEntry(objectId string, ingress *extensionsv1beta1.Ingress) bool {
+	hostnames := []string{}
+
+	for _, rule := range ingress.Spec.Rules {
+		if strings.HasSuffix(rule.Host, d.hfd.config.IngressIp) {
+			hostnames = append(hostnames, rule.Host+".")
+		} else {
+			hostnames = append(hostnames, rule.Host)
+		}
+	}
+
+	he := hostsfile.NewHostsEntry(d.hfd.config.IngressIp, hostnames)
+	return d.hfd.hostsfile.SetHostsEntry(objectId, *he)
+}

--- a/pkg/daemon/daemon_ingress_monitor_test.go
+++ b/pkg/daemon/daemon_ingress_monitor_test.go
@@ -1,0 +1,100 @@
+package daemon
+
+import (
+	// "strings"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+import (
+	"github.com/Eagerod/hostsfile-generator/pkg/hostsfile"
+)
+
+func validTestIngress() *extensionsv1beta1.Ingress {
+	ingress := extensionsv1beta1.Ingress{}
+	ingress.ObjectMeta.Namespace = "default"
+	ingress.ObjectMeta.Name = "some-ingress"
+	ingress.Annotations = make(map[string]string)
+	ingress.Annotations["kubernetes.io/ingress.class"] = "nginx"
+
+	ingress.Spec.Rules = []extensionsv1beta1.IngressRule{
+		extensionsv1beta1.IngressRule{
+			Host: "some-ingress.internal.aleemhaji.com",
+		},
+	}
+
+	// for _, rule := range ingress.Spec.Rules {
+	// 	if strings.HasSuffix(rule.Host, d.ingressIp) {
+	// 		hostnames = append(hostnames, rule.Host+".")
+	// 	} else {
+	// 		hostnames = append(hostnames, rule.Host)
+	// 	}
+	// }
+
+	return &ingress
+}
+
+// This file is basically a copy paste of `hostsfile_tests`.
+// Not sure if there's a more sensible technique of testing things that should
+//   have the same interface + behaviour?
+func TestDaemonIngressMonitorName(t *testing.T) {
+	drm := DaemonIngressMonitor{}
+
+	assert.Equal(t, "ingress", drm.Name())
+}
+
+func TestDaemonIngressMonitorValidateResource(t *testing.T) {
+	drm := DaemonIngressMonitor{}
+
+	ingress := validTestIngress()
+
+	objectId, err := drm.ValidateResource(ingress)
+	assert.Nil(t, err)
+	assert.Equal(t, "default/some-ingress", objectId)
+}
+
+func TestDaemonIngressMonitorValidateResourceNotIngress(t *testing.T) {
+	drm := DaemonIngressMonitor{}
+
+	objectId, err := drm.ValidateResource(&drm)
+	assert.Equal(t, "Failed to get ingress from provided object.", err.Error())
+	assert.Equal(t, "", objectId)
+}
+
+func TestDaemonIngressMonitorValidateResourceNoIngressClass(t *testing.T) {
+	drm := DaemonIngressMonitor{}
+
+	ingress := validTestIngress()
+	delete(ingress.Annotations, "kubernetes.io/ingress.class")
+
+	objectId, err := drm.ValidateResource(ingress)
+	assert.Equal(t, "Skipping ingress (default/some-ingress) because it doesn't have an ingress class.", err.Error())
+	assert.Equal(t, "default/some-ingress", objectId)
+}
+
+func TestDaemonIngressMonitorValidateResourceNotNginxIngress(t *testing.T) {
+	drm := DaemonIngressMonitor{}
+
+	ingress := validTestIngress()
+	ingress.Annotations["kubernetes.io/ingress.class"] = "nginx-external"
+
+	objectId, err := drm.ValidateResource(ingress)
+	assert.Equal(t, "Skipping ingress (default/some-ingress) because it doesn't belong to NGINX Ingress Controller.", err.Error())
+	assert.Equal(t, "default/some-ingress", objectId)
+}
+
+func TestDaemonIngressMonitorGetResourceHostsEntry(t *testing.T) {
+	drm := DaemonIngressMonitor{"192.168.1.1"}
+
+	ingress := validTestIngress()
+
+	e := hostsfile.NewHostsEntry("192.168.1.1", []string{"some-ingress.internal.aleemhaji.com"})
+	he := drm.GetResourceHostsEntry(ingress)
+
+	assert.Equal(t, *e, he)
+}

--- a/pkg/daemon/daemon_ingress_monitor_test.go
+++ b/pkg/daemon/daemon_ingress_monitor_test.go
@@ -77,12 +77,21 @@ func TestDaemonIngressMonitorValidateResourceNotNginxIngress(t *testing.T) {
 }
 
 func TestDaemonIngressMonitorGetResourceHostsEntry(t *testing.T) {
-	drm := DaemonIngressMonitor{"192.168.1.1"}
+	drm := DaemonIngressMonitor{"192.168.1.1", "internal.aleemhaji.com"}
 
 	ingress := validTestIngress()
 
-	e := hostsfile.NewHostsEntry("192.168.1.1", []string{"some-ingress.internal.aleemhaji.com"})
+	e := hostsfile.NewHostsEntry("192.168.1.1", []string{"some-ingress.internal.aleemhaji.com."})
 	he := drm.GetResourceHostsEntry(ingress)
+	assert.Equal(t, *e, he)
 
+	ingress.Spec.Rules = []extensionsv1beta1.IngressRule{
+		extensionsv1beta1.IngressRule{
+			Host: "some-ingress",
+		},
+	}
+
+	e = hostsfile.NewHostsEntry("192.168.1.1", []string{"some-ingress"})
+	he = drm.GetResourceHostsEntry(ingress)
 	assert.Equal(t, *e, he)
 }

--- a/pkg/daemon/daemon_ingress_monitor_test.go
+++ b/pkg/daemon/daemon_ingress_monitor_test.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	// "strings"
 	"testing"
 )
 
@@ -28,20 +27,9 @@ func validTestIngress() *extensionsv1beta1.Ingress {
 		},
 	}
 
-	// for _, rule := range ingress.Spec.Rules {
-	// 	if strings.HasSuffix(rule.Host, d.ingressIp) {
-	// 		hostnames = append(hostnames, rule.Host+".")
-	// 	} else {
-	// 		hostnames = append(hostnames, rule.Host)
-	// 	}
-	// }
-
 	return &ingress
 }
 
-// This file is basically a copy paste of `hostsfile_tests`.
-// Not sure if there's a more sensible technique of testing things that should
-//   have the same interface + behaviour?
 func TestDaemonIngressMonitorName(t *testing.T) {
 	drm := DaemonIngressMonitor{}
 

--- a/pkg/daemon/daemon_service_monitor.go
+++ b/pkg/daemon/daemon_service_monitor.go
@@ -1,0 +1,84 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/Eagerod/hostsfile-generator/pkg/hostsfile"
+)
+
+type DaemonServiceMonitor struct {
+	hfd *HostsFileDaemon
+}
+
+func (d *DaemonServiceMonitor) Informer(sif informers.SharedInformerFactory) cache.SharedInformer {
+	return sif.Core().V1().Services().Informer()
+}
+
+func (d *DaemonServiceMonitor) ValidateResource(obj interface{}) (string, error) {
+	service, ok := obj.(*v1.Service)
+	if !ok {
+		return "", errors.New("Failed to get service from provided object.")
+	}
+
+	objectId := fmt.Sprintf("%s/%s", service.ObjectMeta.Namespace, service.ObjectMeta.Name)
+
+	if service.Spec.Type != "LoadBalancer" {
+		return objectId, errors.New(fmt.Sprintf("Skipping service (%s) because it isn't of type LoadBalancer\n", objectId))
+	}
+
+	return objectId, nil
+}
+
+func (d *DaemonServiceMonitor) HandleNewResource(objectId string, obj interface{}) bool {
+	service, ok := obj.(*v1.Service)
+	if !ok {
+		return false
+	}
+
+	if d.setHostsEntry(objectId, service) {
+		log.Println("Updating hostsfile from discovered service", objectId)
+		return true
+	}
+
+	return false
+}
+
+func (d *DaemonServiceMonitor) HandleDeletedResource(objectId string, obj interface{}) bool {
+	_, ok := obj.(*v1.Service)
+	if !ok {
+		return false
+	}
+
+	if d.hfd.hostsfile.RemoveHostsEntry(objectId) {
+		log.Println("Updating hostsfile from removed service", objectId)
+		return true
+	}
+
+	return false
+}
+
+func (d *DaemonServiceMonitor) HandleUpdatedResource(objectId string, obj interface{}) bool {
+	service, ok := obj.(*v1.Service)
+	if !ok {
+		return false
+	}
+
+	if d.setHostsEntry(objectId, service) {
+		log.Println("Updating hostsfile from updated service", objectId)
+		return true
+	}
+
+	return false
+}
+
+func (d *DaemonServiceMonitor) setHostsEntry(objectId string, service *v1.Service) bool {
+	fqdn := fmt.Sprintf("%s.%s.", service.ObjectMeta.Name, d.hfd.config.SearchDomain)
+	he := hostsfile.NewHostsEntry(service.Spec.LoadBalancerIP, []string{fqdn})
+	return d.hfd.hostsfile.SetHostsEntry(objectId, *he)
+}

--- a/pkg/daemon/daemon_service_monitor.go
+++ b/pkg/daemon/daemon_service_monitor.go
@@ -13,7 +13,8 @@ import (
 )
 
 type DaemonServiceMonitor struct {
-	hfd *HostsFileDaemon
+	hostsfile    hostsfile.IHostsFile
+	searchDomain string
 }
 
 func (d *DaemonServiceMonitor) Informer(sif informers.SharedInformerFactory) cache.SharedInformer {
@@ -55,7 +56,7 @@ func (d *DaemonServiceMonitor) HandleDeletedResource(objectId string, obj interf
 		return false
 	}
 
-	if d.hfd.hostsfile.RemoveHostsEntry(objectId) {
+	if d.hostsfile.RemoveHostsEntry(objectId) {
 		log.Println("Updating hostsfile from removed service", objectId)
 		return true
 	}
@@ -78,7 +79,7 @@ func (d *DaemonServiceMonitor) HandleUpdatedResource(objectId string, obj interf
 }
 
 func (d *DaemonServiceMonitor) setHostsEntry(objectId string, service *v1.Service) bool {
-	fqdn := fmt.Sprintf("%s.%s.", service.ObjectMeta.Name, d.hfd.config.SearchDomain)
+	fqdn := fmt.Sprintf("%s.%s.", service.ObjectMeta.Name, d.searchDomain)
 	he := hostsfile.NewHostsEntry(service.Spec.LoadBalancerIP, []string{fqdn})
-	return d.hfd.hostsfile.SetHostsEntry(objectId, *he)
+	return d.hostsfile.SetHostsEntry(objectId, *he)
 }

--- a/pkg/daemon/daemon_service_monitor.go
+++ b/pkg/daemon/daemon_service_monitor.go
@@ -12,7 +12,6 @@ import (
 )
 
 type DaemonServiceMonitor struct {
-	hostsfile    hostsfile.IHostsFile
 	searchDomain string
 }
 
@@ -33,7 +32,7 @@ func (d *DaemonServiceMonitor) ValidateResource(obj interface{}) (string, error)
 	objectId := fmt.Sprintf("%s/%s", service.ObjectMeta.Namespace, service.ObjectMeta.Name)
 
 	if service.Spec.Type != "LoadBalancer" {
-		return objectId, errors.New(fmt.Sprintf("Skipping service (%s) because it isn't of type LoadBalancer\n", objectId))
+		return objectId, fmt.Errorf("Skipping service (%s) because it isn't of type LoadBalancer.", objectId)
 	}
 
 	return objectId, nil

--- a/pkg/daemon/daemon_service_monitor.go
+++ b/pkg/daemon/daemon_service_monitor.go
@@ -16,6 +16,10 @@ type DaemonServiceMonitor struct {
 	searchDomain string
 }
 
+func (d *DaemonServiceMonitor) Name() string {
+	return "service"
+}
+
 func (d *DaemonServiceMonitor) Informer(sif informers.SharedInformerFactory) cache.SharedInformer {
 	return sif.Core().V1().Services().Informer()
 }

--- a/pkg/daemon/daemon_service_monitor_test.go
+++ b/pkg/daemon/daemon_service_monitor_test.go
@@ -1,0 +1,71 @@
+package daemon
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/api/core/v1"
+)
+
+import (
+	"github.com/Eagerod/hostsfile-generator/pkg/hostsfile"
+)
+
+func validTestService() *v1.Service {
+	service := v1.Service{}
+	service.ObjectMeta.Namespace = "default"
+	service.ObjectMeta.Name = "some-service"
+	service.Spec.Type = "LoadBalancer"
+	service.Spec.LoadBalancerIP = "192.168.1.2"
+
+	return &service
+}
+
+func TestDaemonServiceMonitorName(t *testing.T) {
+	drm := DaemonServiceMonitor{}
+
+	assert.Equal(t, "service", drm.Name())
+}
+
+func TestDaemonServiceMonitorValidateResource(t *testing.T) {
+	drm := DaemonServiceMonitor{}
+
+	service := validTestService()
+
+	objectId, err := drm.ValidateResource(service)
+	assert.Nil(t, err)
+	assert.Equal(t, "default/some-service", objectId)
+}
+
+func TestDaemonServiceMonitorValidateResourceNotService(t *testing.T) {
+	drm := DaemonServiceMonitor{}
+
+	objectId, err := drm.ValidateResource(&drm)
+	assert.Equal(t, "Failed to get service from provided object.", err.Error())
+	assert.Equal(t, "", objectId)
+}
+
+func TestDaemonServiceMonitorValidateResourceNotLoadBalancer(t *testing.T) {
+	drm := DaemonServiceMonitor{}
+
+	service := validTestService()
+	service.Spec.Type = "NodePort"
+
+	objectId, err := drm.ValidateResource(service)
+	assert.Equal(t, "Skipping service (default/some-service) because it isn't of type LoadBalancer.", err.Error())
+	assert.Equal(t, "default/some-service", objectId)
+}
+
+func TestDaemonServiceMonitorGetResourceHostsEntry(t *testing.T) {
+	drm := DaemonServiceMonitor{"internal.aleemhaji.com"}
+
+	service := validTestService()
+
+	e := hostsfile.NewHostsEntry("192.168.1.2", []string{"some-service.internal.aleemhaji.com."})
+	he := drm.GetResourceHostsEntry(service)
+
+	assert.Equal(t, *e, he)
+}

--- a/pkg/daemon/hostsfile_daemon.go
+++ b/pkg/daemon/hostsfile_daemon.go
@@ -47,7 +47,7 @@ func (hfd *HostsFileDaemon) Run() {
 	defer close(updatesChannel)
 
 	go hfd.performUpdates(updatesChannel)
-	go hfd.Monitor(updatesChannel, &DaemonIngressMonitor{hfd.hostsfile, hfd.config.IngressIp})
+	go hfd.Monitor(updatesChannel, &DaemonIngressMonitor{hfd.config.IngressIp})
 	go hfd.Monitor(updatesChannel, &DaemonServiceMonitor{hfd.hostsfile, hfd.config.SearchDomain})
 	go updateAfterInterval(updatesChannel, time.Second*60)
 

--- a/pkg/daemon/hostsfile_daemon.go
+++ b/pkg/daemon/hostsfile_daemon.go
@@ -48,7 +48,7 @@ func (hfd *HostsFileDaemon) Run() {
 
 	go hfd.performUpdates(updatesChannel)
 	go hfd.Monitor(updatesChannel, &DaemonIngressMonitor{hfd.config.IngressIp})
-	go hfd.Monitor(updatesChannel, &DaemonServiceMonitor{hfd.hostsfile, hfd.config.SearchDomain})
+	go hfd.Monitor(updatesChannel, &DaemonServiceMonitor{hfd.config.SearchDomain})
 	go updateAfterInterval(updatesChannel, time.Second*60)
 
 	interrupt.WaitForAnySignal(syscall.SIGINT, syscall.SIGTERM)

--- a/pkg/daemon/hostsfile_daemon.go
+++ b/pkg/daemon/hostsfile_daemon.go
@@ -63,7 +63,7 @@ func (hfd *HostsFileDaemon) Monitor(drm DaemonResourceMonitor) {
 
 	drm.Informer(informerFactory).AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: hfd.InformerAddFunc(drm),
+			AddFunc:    hfd.InformerAddFunc(drm),
 			DeleteFunc: hfd.InformerDeleteFunc(drm),
 			UpdateFunc: hfd.InformerUpdateFunc(drm),
 		},

--- a/pkg/daemon/hostsfile_daemon.go
+++ b/pkg/daemon/hostsfile_daemon.go
@@ -27,46 +27,145 @@ type DaemonResourceMonitor interface {
 }
 
 type HostsFileDaemon struct {
-	config    DaemonConfig
-	hostsfile hostsfile.IHostsFile
+	config         DaemonConfig
+	hostsfile      hostsfile.IHostsFile
+	updatesChannel chan bool
 }
 
 type IHostsFileDaemon interface {
 	Run()
 
-	Monitor(c chan<- bool, drm DaemonResourceMonitor)
+	Monitor(drm DaemonResourceMonitor)
 }
 
 func NewHostsFileDaemon(config DaemonConfig) *HostsFileDaemon {
-	hfd := HostsFileDaemon{config, hostsfile.NewConcurrentHostsFile()}
+	hfd := HostsFileDaemon{
+		config,
+		hostsfile.NewConcurrentHostsFile(),
+		make(chan bool, 100),
+	}
 	return &hfd
 }
 
 func (hfd *HostsFileDaemon) Run() {
-	updatesChannel := make(chan bool, 100)
-	defer close(updatesChannel)
+	defer close(hfd.updatesChannel)
 
-	go hfd.performUpdates(updatesChannel)
-	go hfd.Monitor(updatesChannel, &DaemonIngressMonitor{hfd.config.IngressIp, hfd.config.SearchDomain})
-	go hfd.Monitor(updatesChannel, &DaemonServiceMonitor{hfd.config.SearchDomain})
-	go updateAfterInterval(updatesChannel, time.Second*60)
+	go hfd.performUpdates()
+	go hfd.Monitor(&DaemonIngressMonitor{hfd.config.IngressIp, hfd.config.SearchDomain})
+	go hfd.Monitor(&DaemonServiceMonitor{hfd.config.SearchDomain})
+	go hfd.updateAfterInterval(time.Second*60)
 
 	interrupt.WaitForAnySignal(syscall.SIGINT, syscall.SIGTERM)
 }
 
+func (hfd *HostsFileDaemon) Monitor(drm DaemonResourceMonitor) {
+	// Resync every minute, just in case something somehow gets missed.
+	informerFactory := informers.NewSharedInformerFactory(hfd.config.KubernetesClientSet, time.Minute)
+
+	drm.Informer(informerFactory).AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				objectId, err := drm.ValidateResource(obj)
+				if err != nil {
+					return
+				}
+
+				if hfd.hostsfile.SetHostsEntry(objectId, drm.GetResourceHostsEntry(obj)) {
+					log.Printf("Creating entry for %s: %s\n", drm.Name(), objectId)
+					hfd.updatesChannel <- true
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				objectId, err := drm.ValidateResource(obj)
+				if err != nil {
+					return
+				}
+
+				if hfd.hostsfile.RemoveHostsEntry(objectId) {
+					log.Printf("Remove entry for %s: %s\n", drm.Name(), objectId)
+					hfd.updatesChannel <- true
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				objectId, err := drm.ValidateResource(newObj)
+				if err != nil {
+					if objectId != "" &&  hfd.hostsfile.RemoveHostsEntry(objectId) {
+						log.Printf("Removing outdated entry %s: %s\n", drm.Name(), objectId)
+						hfd.updatesChannel <- true
+					}
+					return
+				}
+
+				if hfd.hostsfile.SetHostsEntry(objectId, drm.GetResourceHostsEntry(newObj)) {
+					log.Printf("Updating entry for %s: %s\n", drm.Name(), objectId)
+					hfd.updatesChannel <- true
+				}
+			},
+		},
+	)
+
+	stop := make(chan struct{})
+	informerFactory.Start(stop)
+	informerFactory.WaitForCacheSync(stop)
+}
+
+func (hfd *HostsFileDaemon) performUpdates() {
+	lastUpdate := time.Now()
+	for _ = range hfd.updatesChannel {
+		// Check the length of the channel before doing anything.
+		// If there are more items in it, just let the next iteration
+		//    handle the update.
+		if len(hfd.updatesChannel) >= 1 {
+			continue
+		}
+
+		hostsfile := hfd.hostsfile.String()
+		// If the last update was more than 60 seconds ago, write this one
+		//   immediately
+		if time.Now().Sub(lastUpdate).Minutes() >= 1 {
+			log.Println("Last update was more than 1 minute ago. Updating immediately.")
+			err := WriteHostsFileAndRestartPihole(&hfd.config, hostsfile)
+			if err != nil {
+				log.Fatal(err)
+			}
+			lastUpdate = time.Now()
+			continue
+		}
+
+		// Wait 3 seconds.
+		log.Println("Waiting 1 seconds before attempting hostsfile update.")
+		time.Sleep(time.Second * 1)
+		if len(hfd.updatesChannel) >= 1 {
+			log.Println("Aborting hostsfile update. Newer hostsfile is pending.")
+			continue
+		}
+
+		err := WriteHostsFileAndRestartPihole(&hfd.config, hostsfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		lastUpdate = time.Now()
+	}
+}
+
+func (hfd *HostsFileDaemon) updateAfterInterval(delay time.Duration) {
+	time.Sleep(delay)
+	log.Println("Forcing update to ensure consistency")
+	hfd.updatesChannel <- true
+}
+
 func WriteHostsFileAndRestartPihole(daemonConfig *DaemonConfig, hostsfile string) error {
 	log.Println("Updating kube.list in pod:", daemonConfig.PiholePodName)
-	fmt.Println(hostsfile)
-	// if err := CopyFileToPod(daemonConfig, "/etc/pihole/kube.list", hostsfile); err != nil {
-	// 	return err
-	// }
+	if err := CopyFileToPod(daemonConfig, "/etc/pihole/kube.list", hostsfile); err != nil {
+		return err
+	}
 
-	// log.Println("Restarting DNS service in pod:", daemonConfig.PiholePodName)
-	// if err := ExecInPod(daemonConfig, []string{"pihole", "restartdns"}); err != nil {
-	// 	return err
-	// }
+	log.Println("Restarting DNS service in pod:", daemonConfig.PiholePodName)
+	if err := ExecInPod(daemonConfig, []string{"pihole", "restartdns"}); err != nil {
+		return err
+	}
 
-	// log.Println("Successfully restarted DNS service in pod:", daemonConfig.PiholePodName)
+	log.Println("Successfully restarted DNS service in pod:", daemonConfig.PiholePodName)
 	return nil
 }
 
@@ -106,100 +205,4 @@ func ExecInPod(daemonConfig *DaemonConfig, command []string) error {
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 	})
-}
-
-func (hfd *HostsFileDaemon) Monitor(c chan<- bool, drm DaemonResourceMonitor) {
-	// Resync every minute, just in case something somehow gets missed.
-	informerFactory := informers.NewSharedInformerFactory(hfd.config.KubernetesClientSet, time.Minute)
-
-	drm.Informer(informerFactory).AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				objectId, err := drm.ValidateResource(obj)
-				if err != nil {
-					return
-				}
-
-				if hfd.hostsfile.SetHostsEntry(objectId, drm.GetResourceHostsEntry(obj)) {
-					log.Printf("Creating entry for %s: %s\n", drm.Name(), objectId)
-					c <- true
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				objectId, err := drm.ValidateResource(obj)
-				if err != nil {
-					return
-				}
-
-				if hfd.hostsfile.RemoveHostsEntry(objectId) {
-					log.Printf("Remove entry for %s: %s\n", drm.Name(), objectId)
-					c <- true
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				objectId, err := drm.ValidateResource(newObj)
-				if err != nil {
-					if objectId != "" &&  hfd.hostsfile.RemoveHostsEntry(objectId) {
-						log.Printf("Removing outdated entry %s: %s\n", drm.Name(), objectId)
-						c <- true
-					}
-					return
-				}
-
-				if hfd.hostsfile.SetHostsEntry(objectId, drm.GetResourceHostsEntry(newObj)) {
-					log.Printf("Updating entry for %s: %s\n", drm.Name(), objectId)
-					c <- true
-				}
-			},
-		},
-	)
-
-	stop := make(chan struct{})
-	informerFactory.Start(stop)
-	informerFactory.WaitForCacheSync(stop)
-}
-
-func (hfd *HostsFileDaemon) performUpdates(updatesChannel <-chan bool) {
-	lastUpdate := time.Now()
-	for _ = range updatesChannel {
-		// Check the length of the channel before doing anything.
-		// If there are more items in it, just let the next iteration
-		//    handle the update.
-		if len(updatesChannel) >= 1 {
-			continue
-		}
-
-		hostsfile := hfd.hostsfile.String()
-		// If the last update was more than 60 seconds ago, write this one
-		//   immediately
-		if time.Now().Sub(lastUpdate).Minutes() >= 1 {
-			log.Println("Last update was more than 1 minute ago. Updating immediately.")
-			err := WriteHostsFileAndRestartPihole(&hfd.config, hostsfile)
-			if err != nil {
-				log.Fatal(err)
-			}
-			lastUpdate = time.Now()
-			continue
-		}
-
-		// Wait 3 seconds.
-		log.Println("Waiting 1 seconds before attempting hostsfile update.")
-		time.Sleep(time.Second * 1)
-		if len(updatesChannel) >= 1 {
-			log.Println("Aborting hostsfile update. Newer hostsfile is pending.")
-			continue
-		}
-
-		err := WriteHostsFileAndRestartPihole(&hfd.config, hostsfile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		lastUpdate = time.Now()
-	}
-}
-
-func updateAfterInterval(c chan<- bool, delay time.Duration) {
-	time.Sleep(delay)
-	log.Println("Forcing update to ensure consistency")
-	c <- true
 }

--- a/pkg/daemon/hostsfile_daemon.go
+++ b/pkg/daemon/hostsfile_daemon.go
@@ -48,7 +48,7 @@ func (hfd *HostsFileDaemon) Run() {
 	go hfd.performUpdates()
 	go hfd.Monitor(&DaemonIngressMonitor{hfd.config.IngressIp, hfd.config.SearchDomain})
 	go hfd.Monitor(&DaemonServiceMonitor{hfd.config.SearchDomain})
-	go hfd.updateAfterInterval(time.Second*60)
+	go hfd.updateAfterInterval(time.Second * 60)
 
 	interrupt.WaitForAnySignal(syscall.SIGINT, syscall.SIGTERM)
 }
@@ -84,7 +84,7 @@ func (hfd *HostsFileDaemon) Monitor(drm DaemonResourceMonitor) {
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				objectId, err := drm.ValidateResource(newObj)
 				if err != nil {
-					if objectId != "" &&  hfd.hostsfile.RemoveHostsEntry(objectId) {
+					if objectId != "" && hfd.hostsfile.RemoveHostsEntry(objectId) {
 						log.Printf("Removing outdated entry %s: %s\n", drm.Name(), objectId)
 						hfd.updatesChannel <- true
 					}

--- a/pkg/daemon/hostsfile_daemon.go
+++ b/pkg/daemon/hostsfile_daemon.go
@@ -1,0 +1,197 @@
+package daemon
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/Eagerod/hostsfile-generator/pkg/hostsfile"
+	"github.com/Eagerod/hostsfile-generator/pkg/interrupt"
+)
+
+// Basically a container for informers
+type DaemonResourceMonitor interface {
+	Informer(sif informers.SharedInformerFactory) cache.SharedInformer
+
+	ValidateResource(obj interface{}) (string, error)
+	HandleNewResource(objectId string, obj interface{}) bool
+	HandleDeletedResource(objectId string, obj interface{}) bool
+	HandleUpdatedResource(objectId string, obj interface{}) bool
+}
+
+type HostsFileDaemon struct {
+	config    DaemonConfig
+	hostsfile hostsfile.IHostsFile
+}
+
+type IHostsFileDaemon interface {
+	Run()
+
+	Monitor(c chan<- bool, drm DaemonResourceMonitor)
+}
+
+func NewHostsFileDaemon(config DaemonConfig) *HostsFileDaemon {
+	hfd := HostsFileDaemon{config, hostsfile.NewConcurrentHostsFile()}
+	return &hfd
+}
+
+func (hfd *HostsFileDaemon) Run() {
+	updatesChannel := make(chan bool, 100)
+	defer close(updatesChannel)
+
+	go func() {
+		lastUpdate := time.Now()
+		for _ = range updatesChannel {
+			// Check the length of the channel before doing anything.
+			// If there are more items in it, just let the next iteration
+			//    handle the update.
+			if len(updatesChannel) >= 1 {
+				continue
+			}
+
+			hostsfile := hfd.hostsfile.String()
+			// If the last update was more than 60 seconds ago, write this one
+			//   immediately
+			if time.Now().Sub(lastUpdate).Minutes() >= 1 {
+				log.Println("Last update was more than 1 minute ago. Updating immediately.")
+				err := WriteHostsFileAndRestartPihole(&hfd.config, hostsfile)
+				if err != nil {
+					log.Fatal(err)
+				}
+				lastUpdate = time.Now()
+				continue
+			}
+
+			// Wait 3 seconds.
+			log.Println("Waiting 1 seconds before attempting hostsfile update.")
+			time.Sleep(time.Second * 1)
+			if len(updatesChannel) >= 1 {
+				log.Println("Aborting hostsfile update. Newer hostsfile is pending.")
+				continue
+			}
+
+			err := WriteHostsFileAndRestartPihole(&hfd.config, hostsfile)
+			if err != nil {
+				log.Fatal(err)
+			}
+			lastUpdate = time.Now()
+		}
+	}()
+
+	go hfd.Monitor(updatesChannel, &DaemonIngressMonitor{hfd})
+	go hfd.Monitor(updatesChannel, &DaemonServiceMonitor{hfd})
+
+	go func() {
+		time.Sleep(time.Second * 60)
+		log.Println("Forcing update of hostsfile to ensure initial launch configurations persist")
+		updatesChannel <- true
+	}()
+
+	interrupt.WaitForAnySignal(syscall.SIGINT, syscall.SIGTERM)
+}
+
+func WriteHostsFileAndRestartPihole(daemonConfig *DaemonConfig, hostsfile string) error {
+	log.Println("Updating kube.list in pod:", daemonConfig.PiholePodName)
+	fmt.Println(hostsfile)
+	// if err := CopyFileToPod(daemonConfig, "/etc/pihole/kube.list", hostsfile); err != nil {
+	// 	return err
+	// }
+
+	// log.Println("Restarting DNS service in pod:", daemonConfig.PiholePodName)
+	// if err := ExecInPod(daemonConfig, []string{"pihole", "restartdns"}); err != nil {
+	// 	return err
+	// }
+
+	// log.Println("Successfully restarted DNS service in pod:", daemonConfig.PiholePodName)
+	return nil
+}
+
+func CopyFileToPod(daemonConfig *DaemonConfig, filepath string, contents string) error {
+	// There's certainly a more correct way of doing this, but that's a lot of
+	//   extra code.
+	script := fmt.Sprintf("cat <<EOF > %s\n%s\nEOF", filepath, contents)
+	return ExecInPod(daemonConfig, []string{"sh", "-c", script})
+}
+
+func ExecInPod(daemonConfig *DaemonConfig, command []string) error {
+	api := daemonConfig.KubernetesClientSet.CoreV1()
+
+	execResource := api.RESTClient().Post().Resource("pods").Name(daemonConfig.PiholePodName).
+		Namespace("default").SubResource("exec").Param("container", "pihole")
+
+	podExecOptions := &v1.PodExecOptions{
+		Command: command,
+		Stdin:   true,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     true,
+	}
+
+	execResource.VersionedParams(
+		podExecOptions,
+		scheme.ParameterCodec,
+	)
+
+	exec, err := remotecommand.NewSPDYExecutor(daemonConfig.RestConfig, "POST", execResource.URL())
+	if err != nil {
+		return err
+	}
+
+	return exec.Stream(remotecommand.StreamOptions{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	})
+}
+
+func (hfd *HostsFileDaemon) Monitor(c chan<- bool, drm DaemonResourceMonitor) {
+	// Resync every minute, just in case something somehow gets missed.
+	informerFactory := informers.NewSharedInformerFactory(hfd.config.KubernetesClientSet, time.Minute)
+
+	drm.Informer(informerFactory).AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				objectId, err := drm.ValidateResource(obj)
+				if err != nil {
+					return
+				}
+
+				if drm.HandleNewResource(objectId, obj) {
+					c <- true
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				objectId, err := drm.ValidateResource(obj)
+				if err != nil {
+					return
+				}
+
+				if drm.HandleDeletedResource(objectId, obj) {
+					c <- true
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				objectId, err := drm.ValidateResource(newObj)
+				if err != nil {
+					return
+				}
+
+				if drm.HandleUpdatedResource(objectId, newObj) {
+					c <- true
+				}
+			},
+		},
+	)
+
+	stop := make(chan struct{})
+	informerFactory.Start(stop)
+	informerFactory.WaitForCacheSync(stop)
+}

--- a/pkg/daemon/hostsfile_daemon.go
+++ b/pkg/daemon/hostsfile_daemon.go
@@ -47,7 +47,7 @@ func (hfd *HostsFileDaemon) Run() {
 	defer close(updatesChannel)
 
 	go hfd.performUpdates(updatesChannel)
-	go hfd.Monitor(updatesChannel, &DaemonIngressMonitor{hfd.config.IngressIp})
+	go hfd.Monitor(updatesChannel, &DaemonIngressMonitor{hfd.config.IngressIp, hfd.config.SearchDomain})
 	go hfd.Monitor(updatesChannel, &DaemonServiceMonitor{hfd.config.SearchDomain})
 	go updateAfterInterval(updatesChannel, time.Second*60)
 

--- a/pkg/daemon/hostsfile_daemon_test.go
+++ b/pkg/daemon/hostsfile_daemon_test.go
@@ -1,0 +1,149 @@
+package daemon
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+func TestInformerAddFunc(t *testing.T) {
+	dc, err := NewDaemonConfig("1", "2", "3", "4", "5")
+	assert.Nil(t, err)
+
+	hfd := NewHostsFileDaemon(*dc)
+	dsm := DaemonIngressMonitor{"1", "2"}
+	f := hfd.InformerAddFunc(&dsm)
+	
+	i := validTestIngress()
+	f(i)
+
+	assert.Equal(t, 1, len(hfd.updatesChannel))
+}
+
+func TestInformerAddFuncWrongType(t *testing.T) {
+	dc, err := NewDaemonConfig("1", "2", "3", "4", "5")
+	assert.Nil(t, err)
+
+	hfd := NewHostsFileDaemon(*dc)
+	dsm := DaemonIngressMonitor{"1", "2"}
+	f := hfd.InformerAddFunc(&dsm)
+	
+	i := validTestService()
+	f(i)
+
+	assert.Equal(t, 0, len(hfd.updatesChannel))
+}
+
+func TestInformerDeleteFunc(t *testing.T) {
+	dc, err := NewDaemonConfig("1", "2", "3", "4", "5")
+	assert.Nil(t, err)
+
+	hfd := NewHostsFileDaemon(*dc)
+	dsm := DaemonIngressMonitor{"1", "2"}
+
+	i := validTestIngress()
+
+	objectId, err := dsm.ValidateResource(i)
+	he := dsm.GetResourceHostsEntry(i)
+	hfd.hostsfile.SetHostsEntry(objectId, he)
+
+	f := hfd.InformerDeleteFunc(&dsm)
+	f(i)
+
+	assert.Equal(t, 1, len(hfd.updatesChannel))
+}
+
+func TestInformerDeleteFuncWrongType(t *testing.T) {
+	dc, err := NewDaemonConfig("1", "2", "3", "4", "5")
+	assert.Nil(t, err)
+
+	hfd := NewHostsFileDaemon(*dc)
+	dsm := DaemonIngressMonitor{"1", "2"}
+
+	i := validTestIngress()
+
+	objectId, err := dsm.ValidateResource(i)
+	he := dsm.GetResourceHostsEntry(i)
+	hfd.hostsfile.SetHostsEntry(objectId, he)
+
+	ii := validTestService()
+	f := hfd.InformerDeleteFunc(&dsm)
+	f(ii)
+
+	assert.Equal(t, 0, len(hfd.updatesChannel))
+}
+
+func TestInformerUpdateFunc(t *testing.T) {
+	dc, err := NewDaemonConfig("1", "2", "3", "4", "5")
+	assert.Nil(t, err)
+
+	hfd := NewHostsFileDaemon(*dc)
+	dsm := DaemonIngressMonitor{"1", "2"}
+
+	i := validTestIngress()
+
+	objectId, err := dsm.ValidateResource(i)
+	he := dsm.GetResourceHostsEntry(i)
+	hfd.hostsfile.SetHostsEntry(objectId, he)
+
+	ii := *i
+	ii.Spec.Rules = []extensionsv1beta1.IngressRule{
+		extensionsv1beta1.IngressRule{
+			Host: "another-ingress.internal.aleemhaji.com",
+		},
+	}
+
+	f := hfd.InformerUpdateFunc(&dsm)
+	f(i, &ii)
+
+	assert.Equal(t, 1, len(hfd.updatesChannel))
+}
+
+func TestInformerUpdateFuncWrongType(t *testing.T) {
+	dc, err := NewDaemonConfig("1", "2", "3", "4", "5")
+	assert.Nil(t, err)
+
+	hfd := NewHostsFileDaemon(*dc)
+	dsm := DaemonIngressMonitor{"1", "2"}
+
+	i := validTestIngress()
+
+	objectId, err := dsm.ValidateResource(i)
+	he := dsm.GetResourceHostsEntry(i)
+	hfd.hostsfile.SetHostsEntry(objectId, he)
+
+	ii := validTestService()
+	f := hfd.InformerUpdateFunc(&dsm)
+	f(i, &ii)
+
+	assert.Equal(t, 0, len(hfd.updatesChannel))
+}
+
+func TestInformerUpdateFuncInvalidated(t *testing.T) {
+	dc, err := NewDaemonConfig("1", "2", "3", "4", "5")
+	assert.Nil(t, err)
+
+	hfd := NewHostsFileDaemon(*dc)
+	dsm := DaemonIngressMonitor{"1", "2"}
+
+	i := validTestIngress()
+
+	objectId, err := dsm.ValidateResource(i)
+	he := dsm.GetResourceHostsEntry(i)
+	hfd.hostsfile.SetHostsEntry(objectId, he)
+
+	ii := *i
+	ii.Annotations["kubernetes.io/ingress.class"] = "nginx-external"
+
+	f := hfd.InformerUpdateFunc(&dsm)
+	f(i, &ii)
+
+	assert.Equal(t, 1, len(hfd.updatesChannel))
+	
+	// Assert that the entry has been removed from the update.
+	assert.False(t, hfd.hostsfile.RemoveHostsEntry(objectId))
+}

--- a/pkg/daemon/hostsfile_daemon_test.go
+++ b/pkg/daemon/hostsfile_daemon_test.go
@@ -17,7 +17,7 @@ func TestInformerAddFunc(t *testing.T) {
 	hfd := NewHostsFileDaemon(*dc)
 	dsm := DaemonIngressMonitor{"1", "2"}
 	f := hfd.InformerAddFunc(&dsm)
-	
+
 	i := validTestIngress()
 	f(i)
 
@@ -31,7 +31,7 @@ func TestInformerAddFuncWrongType(t *testing.T) {
 	hfd := NewHostsFileDaemon(*dc)
 	dsm := DaemonIngressMonitor{"1", "2"}
 	f := hfd.InformerAddFunc(&dsm)
-	
+
 	i := validTestService()
 	f(i)
 
@@ -143,7 +143,7 @@ func TestInformerUpdateFuncInvalidated(t *testing.T) {
 	f(i, &ii)
 
 	assert.Equal(t, 1, len(hfd.updatesChannel))
-	
+
 	// Assert that the entry has been removed from the update.
 	assert.False(t, hfd.hostsfile.RemoveHostsEntry(objectId))
 }

--- a/pkg/daemon/kubernetes_helper.go
+++ b/pkg/daemon/kubernetes_helper.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+func WriteHostsFileAndRestartPihole(config *rest.Config, clientset *kubernetes.Clientset, podName string, hostsfile string) error {
+	log.Println("Updating kube.list in pod:", podName)
+	if err := CopyFileToPod(config, clientset, podName, "/etc/pihole/kube.list", hostsfile); err != nil {
+		return err
+	}
+
+	log.Println("Restarting DNS service in pod:", podName)
+	if err := ExecInPod(config, clientset, podName, []string{"pihole", "restartdns"}); err != nil {
+		return err
+	}
+
+	log.Println("Successfully restarted DNS service in pod:", podName)
+	return nil
+}
+
+func CopyFileToPod(config *rest.Config, clientset *kubernetes.Clientset, podName string, filepath string, contents string) error {
+	// There's certainly a more correct way of doing this, but that's a lot of
+	//   extra code.
+	script := fmt.Sprintf("cat <<EOF > %s\n%s\nEOF", filepath, contents)
+	return ExecInPod(config, clientset, podName, []string{"sh", "-c", script})
+}
+
+func ExecInPod(config *rest.Config, clientset *kubernetes.Clientset, podName string, command []string) error {
+	api := clientset.CoreV1()
+
+	execResource := api.RESTClient().Post().Resource("pods").Name(podName).
+		Namespace("default").SubResource("exec").Param("container", "pihole")
+
+	podExecOptions := &v1.PodExecOptions{
+		Command: command,
+		Stdin:   true,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     true,
+	}
+
+	execResource.VersionedParams(
+		podExecOptions,
+		scheme.ParameterCodec,
+	)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", execResource.URL())
+	if err != nil {
+		return err
+	}
+
+	return exec.Stream(remotecommand.StreamOptions{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	})
+}


### PR DESCRIPTION
Includes moving all of the previous `main.go` into `cmd`, all of the previous `cmd` into `pkg`, and breaking apart everything into smaller files that can be a bit more granularly tested. 

Functionally only fixes one bug in the ingress monitor process that failed to properly set FQDNs in the hostsfile if the expected ingress was a subdomain already under the search domain.