### PR TITLE
Adds in namespacing to resource IDs

### DIFF
--- a/pkg/daemon/daemon_beta_ingress_monitor.go
+++ b/pkg/daemon/daemon_beta_ingress_monitor.go
@@ -31,7 +31,7 @@ func (d *DaemonBetaIngressMonitor) ValidateResource(obj interface{}) (string, er
 		return "", errors.New("failed to get ingress from provided object")
 	}
 
-	objectId := fmt.Sprintf("%s/%s", ingress.ObjectMeta.Namespace, ingress.ObjectMeta.Name)
+	objectId := fmt.Sprintf("extensionsv1beta1.ingress/%s/%s", ingress.ObjectMeta.Namespace, ingress.ObjectMeta.Name)
 
 	ingressClass, ok := ingress.Annotations["kubernetes.io/ingress.class"]
 	if !ok {

--- a/pkg/daemon/daemon_beta_ingress_monitor_test.go
+++ b/pkg/daemon/daemon_beta_ingress_monitor_test.go
@@ -38,7 +38,7 @@ func TestDaemonBetaIngressMonitorValidateResource(t *testing.T) {
 
 	objectId, err := drm.ValidateResource(ingress)
 	assert.Nil(t, err)
-	assert.Equal(t, "default/some-ingress", objectId)
+	assert.Equal(t, "extensionsv1beta1.ingress/default/some-ingress", objectId)
 }
 
 func TestDaemonBetaIngressMonitorValidateResourceNotIngress(t *testing.T) {
@@ -56,8 +56,8 @@ func TestDaemonBetaIngressMonitorValidateResourceNoIngressClass(t *testing.T) {
 	delete(ingress.Annotations, "kubernetes.io/ingress.class")
 
 	objectId, err := drm.ValidateResource(ingress)
-	assert.Equal(t, "skipping ingress (default/some-ingress) because it doesn't have an ingress class", err.Error())
-	assert.Equal(t, "default/some-ingress", objectId)
+	assert.Equal(t, "skipping ingress (extensionsv1beta1.ingress/default/some-ingress) because it doesn't have an ingress class", err.Error())
+	assert.Equal(t, "extensionsv1beta1.ingress/default/some-ingress", objectId)
 }
 
 func TestDaemonBetaIngressMonitorValidateResourceNotNginxIngress(t *testing.T) {
@@ -67,8 +67,8 @@ func TestDaemonBetaIngressMonitorValidateResourceNotNginxIngress(t *testing.T) {
 	ingress.Annotations["kubernetes.io/ingress.class"] = "nginx-external"
 
 	objectId, err := drm.ValidateResource(ingress)
-	assert.Equal(t, "skipping ingress (default/some-ingress) because it doesn't belong to NGINX Ingress Controller", err.Error())
-	assert.Equal(t, "default/some-ingress", objectId)
+	assert.Equal(t, "skipping ingress (extensionsv1beta1.ingress/default/some-ingress) because it doesn't belong to NGINX Ingress Controller", err.Error())
+	assert.Equal(t, "extensionsv1beta1.ingress/default/some-ingress", objectId)
 }
 
 func TestDaemonBetaIngressMonitorGetResourceHostsEntry(t *testing.T) {

--- a/pkg/daemon/daemon_ingress_monitor.go
+++ b/pkg/daemon/daemon_ingress_monitor.go
@@ -31,7 +31,7 @@ func (d *DaemonIngressMonitor) ValidateResource(obj interface{}) (string, error)
 		return "", errors.New("failed to get ingress from provided object")
 	}
 
-	objectId := fmt.Sprintf("%s/%s", ingress.ObjectMeta.Namespace, ingress.ObjectMeta.Name)
+	objectId := fmt.Sprintf("networkingv1.ingress/%s/%s", ingress.ObjectMeta.Namespace, ingress.ObjectMeta.Name)
 
 	ingressClass, ok := ingress.Annotations["kubernetes.io/ingress.class"]
 	if !ok {

--- a/pkg/daemon/daemon_ingress_monitor_test.go
+++ b/pkg/daemon/daemon_ingress_monitor_test.go
@@ -38,7 +38,7 @@ func TestDaemonIngressMonitorValidateResource(t *testing.T) {
 
 	objectId, err := drm.ValidateResource(ingress)
 	assert.Nil(t, err)
-	assert.Equal(t, "default/some-ingress", objectId)
+	assert.Equal(t, "networkingv1.ingress/default/some-ingress", objectId)
 }
 
 func TestDaemonIngressMonitorValidateResourceNotIngress(t *testing.T) {
@@ -56,8 +56,8 @@ func TestDaemonIngressMonitorValidateResourceNoIngressClass(t *testing.T) {
 	delete(ingress.Annotations, "kubernetes.io/ingress.class")
 
 	objectId, err := drm.ValidateResource(ingress)
-	assert.Equal(t, "skipping ingress (default/some-ingress) because it doesn't have an ingress class", err.Error())
-	assert.Equal(t, "default/some-ingress", objectId)
+	assert.Equal(t, "skipping ingress (networkingv1.ingress/default/some-ingress) because it doesn't have an ingress class", err.Error())
+	assert.Equal(t, "networkingv1.ingress/default/some-ingress", objectId)
 }
 
 func TestDaemonIngressMonitorValidateResourceNotNginxIngress(t *testing.T) {
@@ -67,8 +67,8 @@ func TestDaemonIngressMonitorValidateResourceNotNginxIngress(t *testing.T) {
 	ingress.Annotations["kubernetes.io/ingress.class"] = "nginx-external"
 
 	objectId, err := drm.ValidateResource(ingress)
-	assert.Equal(t, "skipping ingress (default/some-ingress) because it doesn't belong to NGINX Ingress Controller", err.Error())
-	assert.Equal(t, "default/some-ingress", objectId)
+	assert.Equal(t, "skipping ingress (networkingv1.ingress/default/some-ingress) because it doesn't belong to NGINX Ingress Controller", err.Error())
+	assert.Equal(t, "networkingv1.ingress/default/some-ingress", objectId)
 }
 
 func TestDaemonIngressMonitorGetResourceHostsEntry(t *testing.T) {

--- a/pkg/daemon/daemon_service_monitor.go
+++ b/pkg/daemon/daemon_service_monitor.go
@@ -29,7 +29,7 @@ func (d *DaemonServiceMonitor) ValidateResource(obj interface{}) (string, error)
 		return "", errors.New("failed to get service from provided object")
 	}
 
-	objectId := fmt.Sprintf("%s/%s", service.ObjectMeta.Namespace, service.ObjectMeta.Name)
+	objectId := fmt.Sprintf("v1.service/%s/%s", service.ObjectMeta.Namespace, service.ObjectMeta.Name)
 
 	if service.Spec.Type != "LoadBalancer" {
 		return objectId, fmt.Errorf("skipping service (%s) because it isn't of type LoadBalancer", objectId)

--- a/pkg/daemon/daemon_service_monitor_test.go
+++ b/pkg/daemon/daemon_service_monitor_test.go
@@ -32,7 +32,7 @@ func TestDaemonServiceMonitorValidateResource(t *testing.T) {
 
 	objectId, err := drm.ValidateResource(service)
 	assert.Nil(t, err)
-	assert.Equal(t, "default/some-service", objectId)
+	assert.Equal(t, "v1.service/default/some-service", objectId)
 }
 
 func TestDaemonServiceMonitorValidateResourceNotService(t *testing.T) {
@@ -50,8 +50,8 @@ func TestDaemonServiceMonitorValidateResourceNotLoadBalancer(t *testing.T) {
 	service.Spec.Type = "NodePort"
 
 	objectId, err := drm.ValidateResource(service)
-	assert.Equal(t, "skipping service (default/some-service) because it isn't of type LoadBalancer", err.Error())
-	assert.Equal(t, "default/some-service", objectId)
+	assert.Equal(t, "skipping service (v1.service/default/some-service) because it isn't of type LoadBalancer", err.Error())
+	assert.Equal(t, "v1.service/default/some-service", objectId)
 }
 
 func TestDaemonServiceMonitorGetResourceHostsEntry(t *testing.T) {


### PR DESCRIPTION
Prevents resources of different `kind`s from interfering. 

I was running into an issue where a service and an ingress by the same name would repeatedly try to overwrite each other, leading to DNS records thrashing.